### PR TITLE
Some dd commands don't understand "1M"

### DIFF
--- a/assets/create-debian-setup.sh
+++ b/assets/create-debian-setup.sh
@@ -50,7 +50,7 @@ export DEBOOTSTRAP_DIR=$mnt/usr/share/debootstrap
 echo "Create the image file:"
 
 test -e $image_path || \
-    dd if=/dev/zero of=$image_path seek=$imagesize bs=1M count=1
+    dd if=/dev/zero of=$image_path seek=$imagesize bs=1048576 count=1
 # set them up
 if test -d $mnt && test -e $image_path; then
     mke2fs_options="-L debian_chroot -T `find_best_filesystem` -F $image_path"


### PR DESCRIPTION
The dd command on the Lenovo Thinkpad Tablet ignores the "M" suffix, which results in an image several orders of magnitude too small.
This patch replaces "1M" with the number of bytes (1048576), which should work with any dd implementation.
