### PR TITLE
Lock down date format for faketime

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -96,7 +96,7 @@ script. Running a program with `faketime` causes that program to recent a
 fixed time based on the timestamp provided to `faketime`.  This ensures that
 the timestamps in the files are always the same.
 
-  faketime "`git log -n1 --date=iso | sed -n 's,^Date:\s\s*\(.*\),\1,p'`" \
+  faketime "`git log -n1 --format=format:%ai`" \
     ant clean debug
 
 

--- a/external/Makefile
+++ b/external/Makefile
@@ -63,7 +63,7 @@ ALL_LDFLAGS = -Wl,--gc-sections
 # the speed of the machine that the build process is running on.  See `man
 # faketime` for more info on the "advanced timestamp format".  Also, force
 # time to UTC so its always the same on all machines.
-TIMESTAMP="$(shell faketime "`git log -n1 --date=iso | sed -n 's,^Date:\s\s*\(.*\),\1,p'`" \
+TIMESTAMP="$(shell faketime "`git log -n1 --format=format:%ai`" \
 				date --utc '+%Y-%m-%d %H:%M:%S')"
 export TZ=UTC
 

--- a/make-release-build.sh
+++ b/make-release-build.sh
@@ -9,7 +9,7 @@ if [ -z $ANDROID_HOME ]; then
     fi
 fi
 
-TIMESTAMP=`git log -n1 --date=iso | sed -n 's,^Date:\s\s*\(.*\),\1,p'`
+TIMESTAMP=`git log -n1 --format=format:%ai`
 
 git reset --hard
 git clean -fdx


### PR DESCRIPTION
I had a custom `--format=format:<blah>` config in my user-level gitconfig, and it was throwing an error because sed wasn't matching anything. I'll submit a specific fix to avoid the ambiguity.

(Still can't get it to build deteministically, but I'll find someone in IRC later to run through it with :)
