### PR TITLE
recognize koush superuser when built from source

### DIFF
--- a/src/info/guardianproject/lildebi/LilDebi.java
+++ b/src/info/guardianproject/lildebi/LilDebi.java
@@ -205,6 +205,11 @@ public class LilDebi extends Activity implements OnCreateContextMenuListener {
                     if (Build.VERSION.SDK_INT < 17)
                         foundSU = true;
                 } catch (NameNotFoundException e2) {
+                    try {
+                    	pm.getPackageInfo("com.thirdparty.superuser", PackageManager.GET_ACTIVITIES);
+                    	foundSU = true;
+                    } catch (NameNotFoundException e3) {
+                    }
                 }
             }
         }


### PR DESCRIPTION
unless specified otherwise, koush superuser when built from source uses "com.thirdparty.superuser" so it doesn't conflict with the Play store version. for example, the latest stable android-x86 build (4.4-r1) uses this package name for the built-in version, and LilDebi doesn't see it, prompting the user to install superuser.

https://github.com/koush/Superuser/blob/master/README.md#configuring-the-package-name